### PR TITLE
Update viewer.py

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -9,7 +9,7 @@ from time import sleep
 
 import av
 
-from .control import ControlMixin
+from control import ControlMixin
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(stream=sys.stdout, level=logging.INFO,


### PR DESCRIPTION
Change "from .control import ControlMixin" to "from control import ControlMixin"
Although I am not sure whether "from .control import ControlMixin" can run on Linux, it will report an error on Windows. Can be run on Windows after modification (Python 3.7.7)