### PR TITLE
Solve the problem of high CPU occupation

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -85,7 +85,7 @@ class AndroidViewer(ControlMixin):
         res = self.video_socket.recv(4)
         self.resolution = struct.unpack(">HH", res)
         logger.info("Screen resolution: %s", self.resolution)
-        self.video_socket.setblocking(False)
+        self.video_socket.setblocking(True)
 
     def deploy_server(self, max_width=1024, bitrate=8000000, max_fps=0):
         try:
@@ -131,6 +131,8 @@ class AndroidViewer(ControlMixin):
 
         try:
             raw_h264 = self.video_socket.recv(0x10000)
+            if(raw_h264 == b''):
+                return None
             packets = self.codec.parse(raw_h264)
 
             if not packets:


### PR DESCRIPTION
I found that if video_socket is set to blocking mode, the CPU usage will drop significantly.
Therefore, the corresponding acceptance code should also be modified appropriately.

**For real mobile(watch video):**

  * Before:

![image](https://user-images.githubusercontent.com/26181058/86536440-a2541980-beb5-11ea-844a-d7fcdd5239ca.png)

  * After:

![image](https://user-images.githubusercontent.com/26181058/86536502-24dcd900-beb6-11ea-8109-f4f256af9326.png)


**For emulator mobile(a game):**

  * Before:

![image](https://user-images.githubusercontent.com/26181058/86536541-80a76200-beb6-11ea-9feb-56efd8c3233c.png)

  * After:

![image](https://user-images.githubusercontent.com/26181058/86536562-a7659880-beb6-11ea-816a-a568a80145a2.png)


**This is scrcpy, but scrcpy use GPU. So I think my modification is to effectively reduce the CPU usage**

![image](https://user-images.githubusercontent.com/26181058/86536621-04f9e500-beb7-11ea-8fdc-28504699b6c3.png)
